### PR TITLE
Convert return fields to arrays to allow for multiple retvals

### DIFF
--- a/Classes/BaseActor.json
+++ b/Classes/BaseActor.json
@@ -6,10 +6,12 @@
 			"name": "GetAll",
 			"description": "Returns a table containing all Actors of the class this is called on",
 			"authority": "both",
-			"return": {
-				"type": "Actor[]",
-				"description": "copy of table containing all actors"
-			}
+			"return": [
+				{
+					"type": "Actor[]",
+					"description": "copy of table containing all actors"
+				}
+			]
 		},
 		{
 			"name": "GetByIndex",
@@ -22,29 +24,35 @@
 					"description": "the index of the Actor"
 				}
 			],
-			"return": {
-				"type": "Actor",
-				"description": "Actor at index"
-			}
+			"return": [
+				{
+					"type": "Actor",
+					"description": "Actor at index"
+				}
+			]
 		},
 		{
 			"name": "GetCount",
 			"description": "Returns how many Actors of this class exist",
 			"authority": "both",
-			"return": {
-				"type": "number",
-				"description": "number of Actors of this class"
-			}
+			"return": [
+				{
+					"type": "number",
+					"description": "number of Actors of this class"
+				}
+			]
 		},
 		{
 			"name": "GetPairs",
 			"description": "Returns an iterator with all Actors of this class to be used with <code>pairs()</code>",
 			"description_long": "Returns an iterator with all Actors of this class to be used with <code>pairs()</code>. This is a more performant method than <code>GetAll()</code>, as it will return the iterator to access the Actors directly instead of creating and returning a copy of the Actors table.<br><br><b>Note:</b> Destroying Actors from inside a <code>GetPairs()</code> loop will cause the iterable to change size during the process. If you want to loop-and-destroy, please use <code>GetAll()</code>.",
 			"authority": "both",
-			"return": {
-				"type": "iterator",
-				"description": "Iterator with all Actors of this class"
-			}
+			"return": [
+				{
+					"type": "iterator",
+					"description": "Iterator with all Actors of this class"
+				}
+			]
 		}
 	],
 	"functions": [
@@ -349,148 +357,184 @@
 			"description": "Returns true if this Actor is being destroyed",
 			"description_long": "Returns true if this Actor is being destroyed.<br>You can check this inside events like <code>Drop</code> to see if a Pickable is being dropped because it's going to be destroyed",
 			"authority": "both",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"name": "IsVisible",
 			"description": "Returns true if this Actor is visible",
 			"authority": "both",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"name": "IsGravityEnabled",
 			"description": "Returns true if gravity is enabled on this Actor",
 			"authority": "both",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"name": "IsInWater",
 			"description": "Returns true if this Actor is in water",
 			"authority": "both",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"name": "IsNetworkDistributed",
 			"description": "Returns true if this Actor is currently network distributed",
 			"description_long": "Returns true if this Actor is currently network distributed. Only actors being network distributed can have their network authority set<br>Entities have NetworkDistributed automatically disabled when: Attached, Possessed, Grabbed, Picked Up or Driving",
 			"authority": "both",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"name": "IsValid",
 			"description": "Returns true if this Actor is valid (i.e. wasn't destroyed and points to a valid Actor)",
 			"authority": "both",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"name": "GetAttachedEntities",
 			"description": "Gets all Actors attached to this Actor",
 			"authority": "both",
-			"return": {
-				"type": "Actor[]"
-			}
+			"return": [
+				{
+					"type": "Actor[]"
+				}
+			]
 		},
 		{
 			"name": "GetAttachedTo",
 			"description": "Gets the Actor this Actor is attached to",
 			"authority": "both",
-			"return": {
-				"type": "Actor?"
-			}
+			"return": [
+				{
+					"type": "Actor?"
+				}
+			]
 		},
 		{
 			"name": "GetBounds",
 			"description": "Gets this Actor's bounds",
 			"authority": "client",
-			"return": {
-				"type": "table",
-				"description": "in the format <code>{\"Origin\", \"BoxExtent\", \"SphereRadius\"}</code>"
-			}
+			"return": [
+				{
+					"type": "table",
+					"description": "in the format <code>{\"Origin\", \"BoxExtent\", \"SphereRadius\"}</code>"
+				}
+			]
 		},
 		{
 			"name": "GetCollision",
 			"description": "Gets this Actor's collision type",
 			"authority": "both",
-			"return": {
-				"type": "CollisionType"
-			}
+			"return": [
+				{
+					"type": "CollisionType"
+				}
+			]
 		},
 		{
 			"name": "GetID",
 			"description": "Gets the universal network ID of this Actor (same on both client and server)",
 			"authority": "both",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"name": "GetLocation",
 			"description": "Gets this Actor's location in the game world",
 			"authority": "both",
-			"return": {
-				"type": "Vector"
-			}
+			"return": [
+				{
+					"type": "Vector"
+				}
+			]
 		},
 		{
 			"name": "GetRotation",
 			"description": "Gets this Actor's angle in the game world",
 			"authority": "both",
-			"return": {
-				"type": "Rotator"
-			}
+			"return": [
+				{
+					"type": "Rotator"
+				}
+			]
 		},
 		{
 			"name": "GetForce",
 			"description": "Gets this Actor's force (set by <code>SetForce()</code>)",
 			"authority": "both",
-			"return": {
-				"type": "Vector"
-			}
+			"return": [
+				{
+					"type": "Vector"
+				}
+			]
 		},
 		{
 			"name": "HasNetworkAuthority",
 			"description": "Returns true if the local Player is currently the Network Authority of this Actor",
 			"authority": "client",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"name": "HasAuthority",
 			"description": "Gets if this Actor was spawned by the client side",
 			"authority": "client",
-			"return": {
-				"type": "boolean",
-				"description": "false if it was spawned by the Server or true if it was spawned by the client"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "false if it was spawned by the Server or true if it was spawned by the client"
+				}
+			]
 		},
 		{
 			"name": "GetScale",
 			"description": "Gets this Actor's scale",
 			"authority": "both",
-			"return": {
-				"type": "Vector"
-			}
+			"return": [
+				{
+					"type": "Vector"
+				}
+			]
 		},
 		{
 			"name": "GetType",
 			"description": "Gets the type of this Actor",
 			"authority": "both",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"name": "GetValue",
@@ -507,18 +551,22 @@
 					"description": "Fallback value if key doesn't exist"
 				}
 			],
-			"return": {
-				"type": "any",
-				"description": "Value at key or fallback if key doesn't exist"
-			}
+			"return": [
+				{
+					"type": "any",
+					"description": "Value at key or fallback if key doesn't exist"
+				}
+			]
 		},
 		{
 			"name": "GetVelocity",
 			"description": "Gets this Actor's current velocity",
 			"authority": "both",
-			"return": {
-				"type": "Vector"
-			}
+			"return": [
+				{
+					"type": "Vector"
+				}
+			]
 		},
 		{
 			"name": "AddActorTag",
@@ -546,9 +594,11 @@
 			"name": "GetActorTags",
 			"description": "Gets all Unreal Actor Tags on this Actor",
 			"authority": "client",
-			"return": {
-				"type": "string[]"
-			}
+			"return": [
+				{
+					"type": "string[]"
+				}
+			]
 		},
 		{
 			"name": "Subscribe",
@@ -566,10 +616,12 @@
 					"description": "Function to call when the event is triggered"
 				}
 			],
-			"return": {
-				"type": "function",
-				"description": "Callback that was passed (useful for unsubscribing later if your callback is an anonymous function)"
-			}
+			"return": [
+				{
+					"type": "function",
+					"description": "Callback that was passed (useful for unsubscribing later if your callback is an anonymous function)"
+				}
+			]
 		},
 		{
 			"name": "Unsubscribe",

--- a/Classes/BasePickable.json
+++ b/Classes/BasePickable.json
@@ -149,17 +149,21 @@
 			"authority": "both",
 			"name": "GetAssetName",
 			"description": "Gets the name of the asset this Pickable uses",
-			"return": {
-				"type": "SkeletalMeshPath"
-			}
+			"return": [
+				{
+					"type": "SkeletalMeshPath"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetHandler",
 			"description": "Gets the Character, if it exists, that's holding this Pickable",
-			"return": {
-				"type": "Character?"
-			}
+			"return": [
+				{
+					"type": "Character?"
+				}
+			]
 		}
 	],
 	"events": [
@@ -233,10 +237,12 @@
 					"description": "The Character that interacted with it"
 				}
 			],
-			"return": {
-				"type": "boolean",
-				"description": "Return <code>false</code> to prevent the interaction"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "Return <code>false</code> to prevent the interaction"
+				}
+			]
 		},
 		{
 			"authority": "both",
@@ -265,7 +271,7 @@
 					"name": "self",
 					"description": "The Pickable which has just been used"
 				},
-							{
+				{
 					"type": "Character",
 					"name": "character",
 					"description": "The Character that used it"
@@ -282,7 +288,7 @@
 					"name": "self",
 					"description": "The Pickable which has just stopped being used"
 				},
-							{
+				{
 					"type": "Character",
 					"name": "character",
 					"description": "The Character that stopped using it"

--- a/Classes/Cable.json
+++ b/Classes/Cable.json
@@ -27,20 +27,17 @@
 			"parameters": [
 				{
 					"type": "Actor",
-					"name": "other",
-					"description": ""
+					"name": "other"
 				},
 				{
 					"type": "Vector",
 					"name": "relative_location",
-					"default": "Vector(0, 0, 0)",
-					"description": ""
+					"default": "Vector(0, 0, 0)"
 				},
 				{
 					"type": "string",
 					"name": "bone_name",
-					"default": "",
-					"description": ""
+					"default": ""
 				}
 			]
 		},
@@ -51,20 +48,17 @@
 			"parameters": [
 				{
 					"type": "Actor",
-					"name": "other",
-					"description": ""
+					"name": "other"
 				},
 				{
 					"type": "Vector",
 					"name": "relative_location",
-					"default": "Vector(0, 0, 0)",
-					"description": ""
+					"default": "Vector(0, 0, 0)"
 				},
 				{
 					"type": "string",
 					"name": "bone_name",
-					"default": "",
-					"description": ""
+					"default": ""
 				}
 			]
 		},
@@ -237,19 +231,23 @@
 			"authority": "both",
 			"name": "GetAttachedStartTo",
 			"description": "Gets the Actor attached to Start",
-			"return": {
-				"type": "Actor",
-				"description": "the Actor or nil"
-			}
+			"return": [
+				{
+					"type": "Actor",
+					"description": "the Actor or nil"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetAttachedEndTo",
 			"description": "Gets the Actor attached to End",
-			"return": {
-				"type": "Actor",
-				"description": "the Actor or nil"
-			}
+			"return": [
+				{
+					"type": "Actor",
+					"description": "the Actor or nil"
+				}
+			]
 		}
 	]
 }

--- a/Classes/Character.json
+++ b/Classes/Character.json
@@ -55,35 +55,33 @@
 		{
 			"authority": "server",
 			"name": "ApplyDamage",
-			"return": {
-				"type": "number",
-				"description": "the damage applied"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "the damage applied"
+				}
+			],
 			"description": "Do damage to a character",
 			"description_long": "Do damage to a character, will trigger all related events and apply modified damage based on bone. Also will apply impulse if it's a heavy explosion",
 			"parameters": [
 				{
 					"type": "number",
-					"name": "damage",
-					"description": ""
+					"name": "damage"
 				},
 				{
 					"type": "string",
 					"name": "bone_name",
-					"default": "",
-					"description": ""
+					"default": ""
 				},
 				{
 					"type": "DamageType",
 					"name": "damage_type",
-					"default": "DamageType.Shot",
-					"description": ""
+					"default": "DamageType.Shot"
 				},
 				{
 					"type": "Vector",
 					"name": "from_direction",
-					"default": "Vector(0, 0, 0)",
-					"description": ""
+					"default": "Vector(0, 0, 0)"
 				},
 				{
 					"type": "Player",
@@ -113,8 +111,7 @@
 				{
 					"type": "SkeletalMeshPath",
 					"name": "skeletal_mesh_asset",
-					"default": "",
-					"description": ""
+					"default": ""
 				}
 			]
 		},
@@ -132,26 +129,22 @@
 				{
 					"type": "StaticMeshPath",
 					"name": "static_mesh_asset",
-					"default": "",
-					"description": ""
+					"default": ""
 				},
 				{
 					"type": "string",
 					"name": "socket",
-					"default": "",
-					"description": ""
+					"default": ""
 				},
 				{
 					"type": "Vector",
 					"name": "relative_location",
-					"default": "Vector(0, 0, 0)",
-					"description": ""
+					"default": "Vector(0, 0, 0)"
 				},
 				{
 					"type": "Rotator",
 					"name": "relative_rotation",
-					"default": "Rotator(0, 0, 0)",
-					"description": ""
+					"default": "Rotator(0, 0, 0)"
 				}
 			]
 		},
@@ -169,14 +162,12 @@
 			"parameters": [
 				{
 					"type": "Vehicle",
-					"name": "vehicle",
-					"description": ""
+					"name": "vehicle"
 				},
 				{
 					"type": "number",
 					"name": "seat",
-					"default": "0",
-					"description": ""
+					"default": "0"
 				}
 			]
 		},
@@ -187,8 +178,7 @@
 			"parameters": [
 				{
 					"type": "Prop",
-					"name": "prop",
-					"description": ""
+					"name": "prop"
 				}
 			]
 		},
@@ -222,10 +212,12 @@
 		{
 			"authority": "both",
 			"name": "IsBoneHidden",
-			"return": {
-				"type": "boolean",
-				"description": "if the bone is hidden"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if the bone is hidden"
+				}
+			],
 			"description": "Gets if a bone is hidden",
 			"parameters": [
 				{
@@ -265,14 +257,12 @@
 			"parameters": [
 				{
 					"type": "Vector",
-					"name": "location",
-					"description": ""
+					"name": "location"
 				},
 				{
 					"type": "number",
 					"name": "acceptance_radius",
-					"default": "50",
-					"description": ""
+					"default": "50"
 				}
 			]
 		},
@@ -326,8 +316,7 @@
 			"parameters": [
 				{
 					"type": "Pickable",
-					"name": "pickable",
-					"description": ""
+					"name": "pickable"
 				}
 			]
 		},
@@ -338,38 +327,32 @@
 			"parameters": [
 				{
 					"type": "AnimationPath",
-					"name": "animation_path",
-					"description": ""
+					"name": "animation_path"
 				},
 				{
 					"type": "AnimationSlotType",
 					"name": "slot_type",
-					"default": "AnimationSlotType.FullBody",
-					"description": ""
+					"default": "AnimationSlotType.FullBody"
 				},
 				{
 					"type": "boolean",
 					"name": "loop_indefinitely",
-					"default": "false",
-					"description": ""
+					"default": "false"
 				},
 				{
 					"type": "number",
 					"name": "blend_in_time",
-					"default": "0.25",
-					"description": ""
+					"default": "0.25"
 				},
 				{
 					"type": "number",
 					"name": "blend_out_time",
-					"default": "0.25",
-					"description": ""
+					"default": "0.25"
 				},
 				{
 					"type": "number",
 					"name": "play_rate",
-					"default": "1.0",
-					"description": ""
+					"default": "1.0"
 				},
 				{
 					"type": "boolean",
@@ -386,8 +369,7 @@
 			"parameters": [
 				{
 					"type": "string",
-					"name": "id",
-					"description": ""
+					"name": "id"
 				}
 			]
 		},
@@ -398,8 +380,7 @@
 			"parameters": [
 				{
 					"type": "string",
-					"name": "id",
-					"description": ""
+					"name": "id"
 				}
 			]
 		},
@@ -427,8 +408,7 @@
 				{
 					"type": "Rotator",
 					"name": "rotation",
-					"default": "Rotator(0, 0, 0)",
-					"description": ""
+					"default": "Rotator(0, 0, 0)"
 				}
 			]
 		},
@@ -440,44 +420,37 @@
 				{
 					"type": "number",
 					"name": "walking",
-					"default": "768",
-					"description": ""
+					"default": "768"
 				},
 				{
 					"type": "number",
 					"name": "parachuting",
-					"default": "512",
-					"description": ""
+					"default": "512"
 				},
 				{
 					"type": "number",
 					"name": "skydiving",
-					"default": "768",
-					"description": ""
+					"default": "768"
 				},
 				{
 					"type": "number",
 					"name": "falling",
-					"default": "128",
-					"description": ""
+					"default": "128"
 				},
 				{
 					"type": "number",
 					"name": "swimming",
-					"default": "256",
-					"description": ""
+					"default": "256"
 				},
 				{
 					"type": "number",
 					"name": "swimming_surface",
-					"default": "256",
-					"description": ""
+					"default": "256"
 				},
 				{
 					"type": "number",
 					"name": "flying",
-					"default": "1024",
-					"description": ""
+					"default": "1024"
 				}
 			]
 		},
@@ -489,38 +462,32 @@
 				{
 					"type": "number",
 					"name": "ground_friction",
-					"default": "2",
-					"description": ""
+					"default": "2"
 				},
 				{
 					"type": "number",
 					"name": "braking_friction_factor",
-					"default": "2",
-					"description": ""
+					"default": "2"
 				},
 				{
 					"type": "number",
 					"name": "braking_walking",
-					"default": "96",
-					"description": ""
+					"default": "96"
 				},
 				{
 					"type": "number",
 					"name": "braking_flying",
-					"default": "3000",
-					"description": ""
+					"default": "3000"
 				},
 				{
 					"type": "number",
 					"name": "braking_swimming",
-					"default": "10",
-					"description": ""
+					"default": "10"
 				},
 				{
 					"type": "number",
 					"name": "braking_falling",
-					"default": "0",
-					"description": ""
+					"default": "0"
 				}
 			]
 		},
@@ -532,8 +499,7 @@
 			"parameters": [
 				{
 					"type": "CameraMode",
-					"name": "camera_mode",
-					"description": ""
+					"name": "camera_mode"
 				}
 			]
 		},
@@ -544,8 +510,7 @@
 			"parameters": [
 				{
 					"type": "Vector",
-					"name": "camera_offset",
-					"description": ""
+					"name": "camera_offset"
 				}
 			]
 		},
@@ -556,8 +521,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "can_crouch",
-					"description": ""
+					"name": "can_crouch"
 				}
 			]
 		},
@@ -568,8 +532,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "can_aim",
-					"description": ""
+					"name": "can_aim"
 				}
 			]
 		},
@@ -580,8 +543,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "can_drop",
-					"description": ""
+					"name": "can_drop"
 				}
 			]
 		},
@@ -592,8 +554,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "can_sprint",
-					"description": ""
+					"name": "can_sprint"
 				}
 			]
 		},
@@ -604,8 +565,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "can_grab_props",
-					"description": ""
+					"name": "can_grab_props"
 				}
 			]
 		},
@@ -616,19 +576,18 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "can_pickup",
-					"description": ""
+					"name": "can_pickup"
 				}
 			]
-		},{
+		},
+		{
 			"authority": "server",
 			"name": "SetCanPunch",
 			"description": "Sets if this Character is allowed to Punch",
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "can_punch",
-					"description": ""
+					"name": "can_punch"
 				}
 			]
 		},
@@ -639,8 +598,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "can_deploy_parachute",
-					"description": ""
+					"name": "can_deploy_parachute"
 				}
 			]
 		},
@@ -669,13 +627,11 @@
 			"parameters": [
 				{
 					"type": "string",
-					"name": "bone_name",
-					"description": ""
+					"name": "bone_name"
 				},
 				{
 					"type": "number",
-					"name": "multiplier",
-					"description": ""
+					"name": "multiplier"
 				}
 			]
 		},
@@ -686,8 +642,7 @@
 			"parameters": [
 				{
 					"type": "string",
-					"name": "sound_asset",
-					"description": ""
+					"name": "sound_asset"
 				}
 			]
 		},
@@ -711,8 +666,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "flying_mode",
-					"description": ""
+					"name": "flying_mode"
 				}
 			]
 		},
@@ -723,8 +677,7 @@
 			"parameters": [
 				{
 					"type": "number",
-					"name": "multiplier",
-					"description": ""
+					"name": "multiplier"
 				}
 			]
 		},
@@ -748,8 +701,7 @@
 			"parameters": [
 				{
 					"type": "GaitMode",
-					"name": "mode",
-					"description": ""
+					"name": "mode"
 				}
 			]
 		},
@@ -761,8 +713,7 @@
 			"parameters": [
 				{
 					"type": "number",
-					"name": "scale",
-					"description": ""
+					"name": "scale"
 				}
 			]
 		},
@@ -774,8 +725,7 @@
 			"parameters": [
 				{
 					"type": "number",
-					"name": "new_health",
-					"description": ""
+					"name": "new_health"
 				}
 			]
 		},
@@ -799,8 +749,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "is_invulnerable",
-					"description": ""
+					"name": "is_invulnerable"
 				}
 			]
 		},
@@ -823,8 +772,7 @@
 			"parameters": [
 				{
 					"type": "number",
-					"name": "new_max_health",
-					"description": ""
+					"name": "new_max_health"
 				}
 			]
 		},
@@ -835,8 +783,7 @@
 			"parameters": [
 				{
 					"type": "SkeletalMeshPath",
-					"name": "skeletal_mesh_asset",
-					"description": ""
+					"name": "skeletal_mesh_asset"
 				}
 			]
 		},
@@ -852,8 +799,7 @@
 				},
 				{
 					"type": "number",
-					"name": "value",
-					"description": ""
+					"name": "value"
 				}
 			]
 		},
@@ -861,10 +807,12 @@
 			"authority": "both",
 			"name": "GetMorphTarget",
 			"description": "Returns the value of a Morph Target",
-			"return": {
-				"type": "number",
-				"description": "value of the Morph Target"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "value of the Morph Target"
+				}
+			],
 			"parameters": [
 				{
 					"type": "string",
@@ -882,10 +830,12 @@
 			"authority": "client",
 			"name": "GetAllMorphTargetNames",
 			"description": "Returns a table with all morph targets available",
-			"return": {
-				"type": "string[]",
-				"description": "table with all morph targets available"
-			}
+			"return": [
+				{
+					"type": "string[]",
+					"description": "table with all morph targets available"
+				}
+			]
 		},
 		{
 			"authority": "both",
@@ -957,8 +907,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "is_movement_enabled",
-					"description": ""
+					"name": "is_movement_enabled"
 				}
 			]
 		},
@@ -969,8 +918,7 @@
 			"parameters": [
 				{
 					"type": "ImagePath",
-					"name": "texture",
-					"description": ""
+					"name": "texture"
 				}
 			]
 		},
@@ -981,8 +929,7 @@
 			"parameters": [
 				{
 					"type": "SoundPath",
-					"name": "sound_asset",
-					"description": ""
+					"name": "sound_asset"
 				}
 			]
 		},
@@ -1005,8 +952,7 @@
 			"parameters": [
 				{
 					"type": "boolean",
-					"name": "ragdoll_enabled",
-					"description": ""
+					"name": "ragdoll_enabled"
 				}
 			]
 		},
@@ -1029,8 +975,7 @@
 			"parameters": [
 				{
 					"type": "StanceMode",
-					"name": "mode",
-					"description": ""
+					"name": "mode"
 				}
 			]
 		},
@@ -1053,8 +998,7 @@
 			"parameters": [
 				{
 					"type": "ViewMode",
-					"name": "view_mode",
-					"description": ""
+					"name": "view_mode"
 				}
 			]
 		},
@@ -1065,8 +1009,7 @@
 			"parameters": [
 				{
 					"type": "AimMode",
-					"name": "aim_mode",
-					"description": ""
+					"name": "aim_mode"
 				}
 			]
 		},
@@ -1077,8 +1020,7 @@
 			"parameters": [
 				{
 					"type": "AnimationPath",
-					"name": "animation_asset",
-					"description": ""
+					"name": "animation_asset"
 				}
 			]
 		},
@@ -1091,107 +1033,133 @@
 			"authority": "both",
 			"name": "IsInRagdollMode",
 			"description": "Gets if Character is in ragdoll mode",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "IsInvulnerable",
 			"description": "Gets if is invulnerable",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "IsMovementEnabled",
 			"description": "Gets if has movement enabled",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCameraMode",
 			"description": "Gets the camera mode",
-			"return": {
-				"type": "CameraMode"
-			}
+			"return": [
+				{
+					"type": "CameraMode"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCanDrop",
 			"description": "Gets if can drop",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCanPunch",
 			"description": "Gets if can punch",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCanAim",
 			"description": "Gets if can aim",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCanCrouch",
 			"description": "Gets if can crouch",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCanSprint",
 			"description": "Gets if can sprint",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCanGrabProps",
 			"description": "Gets if can grab props",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCanPickupPickables",
 			"description": "Gets if can pickup Pickables (Weapons, Melee, Grenade...)",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCapsuleSize",
 			"description": "Gets the Capsule Size",
-			"return": {
-				"type": "table",
-				"description": "table in the format <code>{ Radius, HalfHeight }</code>"
-			}
+			"return": [
+				{
+					"type": "table",
+					"description": "table in the format <code>{ Radius, HalfHeight }</code>"
+				}
+			]
 		},
 		{
 			"authority": "client",
 			"name": "GetBoneTransform",
 			"description": "Gets a Bone Transform in world space given a bone name",
-			"return": {
-				"type": "table",
-				"description": "table in the format <code>{ Location, Rotation }</code>"
-			},
+			"return": [
+				{
+					"type": "table",
+					"description": "table in the format <code>{ Location, Rotation }</code>"
+				}
+			],
 			"parameters": [
 				{
 					"name": "bone_name",
@@ -1203,18 +1171,22 @@
 			"authority": "both",
 			"name": "GetControlRotation",
 			"description": "Gets the Control Rotation",
-			"return": {
-				"type": "Rotator"
-			}
+			"return": [
+				{
+					"type": "Rotator"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetDamageMultiplier",
 			"description": "Gets the Damage Multiplier of a bone",
-			"return": {
-				"type": "number",
-				"description": "the damage multiplier of the bone"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "the damage multiplier of the bone"
+				}
+			],
 			"parameters": [
 				{
 					"name": "bone_name",
@@ -1226,178 +1198,222 @@
 			"authority": "both",
 			"name": "GetFallDamageTaken",
 			"description": "Gets the Fall Damage",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetFallingMode",
 			"description": "Gets the FallingMode",
-			"return": {
-				"type": "FallingMode"
-			}
+			"return": [
+				{
+					"type": "FallingMode"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetFlyingMode",
 			"description": "Gets if it's in Flying mode",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetGaitMode",
 			"description": "Gets the GaitMode",
-			"return": {
-				"type": "GaitMode"
-			}
+			"return": [
+				{
+					"type": "GaitMode"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetGrabbedProp",
 			"description": "Gets the Grabbed Prop",
-			"return": {
-				"type": "Prop?"
-			}
+			"return": [
+				{
+					"type": "Prop?"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetGravityScale",
 			"description": "Gets the gravity scale",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetHealth",
 			"description": "Gets the current health",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetImpactDamageTaken",
 			"description": "Gets the impact damage taken",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetJumpZVelocity",
 			"description": "Gets the Jump Z Velocity",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetMaxHealth",
 			"description": "Gets the Max Health",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetMesh",
 			"description": "Gets the Skeletal Mesh Asset",
-			"return": {
-				"type": "SkeletalMeshPath"
-			}
+			"return": [
+				{
+					"type": "SkeletalMeshPath"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetMovingTo",
 			"description": "Gets the Moving To location",
-			"return": {
-				"type": "Vector",
-				"description": "the moving to location or Vector(0, 0, 0) if not moving"
-			}
+			"return": [
+				{
+					"type": "Vector",
+					"description": "the moving to location or Vector(0, 0, 0) if not moving"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetPicked",
 			"description": "Gets the Pickable if picking up",
-			"return": {
-				"type": "Pickable?"
-			}
+			"return": [
+				{
+					"type": "Pickable?"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetPlayer",
 			"description": "Gets the possessing Player",
-			"return": {
-				"type": "Player?"
-			}
+			"return": [
+				{
+					"type": "Player?"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetPunchDamage",
 			"description": "Gets the punch damage",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSpeedMultiplier",
 			"description": "Gets the speed multiplier",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetStanceMode",
 			"description": "Gets the Stance Mode",
-			"return": {
-				"type": "StanceMode"
-			}
+			"return": [
+				{
+					"type": "StanceMode"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSwimmingMode",
 			"description": "Gets the Swimming Mode",
-			"return": {
-				"type": "SwimmingMode"
-			}
+			"return": [
+				{
+					"type": "SwimmingMode"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetTeam",
 			"description": "Gets the Team",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetVehicle",
 			"description": "Gets the entered Vehicle",
-			"return": {
-				"type": "Vehicle?"
-			}
+			"return": [
+				{
+					"type": "Vehicle?"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetViewMode",
 			"description": "Gets the View Mode",
-			"return": {
-				"type": "ViewMode"
-			}
+			"return": [
+				{
+					"type": "ViewMode"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetWeaponAimMode",
 			"description": "Gets the Weapon Aim Mode",
-			"return": {
-				"type": "AimMode"
-			}
+			"return": [
+				{
+					"type": "AimMode"
+				}
+			]
 		}
 	],
 	"events": [
@@ -1408,13 +1424,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "string",
-					"name": "notify_name",
-					"description": ""
+					"name": "notify_name"
 				}
 			]
 		},
@@ -1425,13 +1439,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "string",
-					"name": "notify_name",
-					"description": ""
+					"name": "notify_name"
 				}
 			]
 		},
@@ -1442,33 +1454,27 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "number",
-					"name": "last_damage_taken",
-					"description": ""
+					"name": "last_damage_taken"
 				},
 				{
 					"type": "string",
-					"name": "last_bone_damaged",
-					"description": ""
+					"name": "last_bone_damaged"
 				},
 				{
 					"type": "DamageType",
-					"name": "damage_type_reason",
-					"description": ""
+					"name": "damage_type_reason"
 				},
 				{
 					"type": "Vector",
-					"name": "hit_from_direction",
-					"description": ""
+					"name": "hit_from_direction"
 				},
 				{
 					"type": "Player?",
-					"name": "instigator",
-					"description": ""
+					"name": "instigator"
 				},
 				{
 					"type": "Actor?",
@@ -1484,18 +1490,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Pickable",
-					"name": "object",
-					"description": ""
+					"name": "object"
 				},
 				{
 					"type": "boolean",
-					"name": "triggered_by_player",
-					"description": ""
+					"name": "triggered_by_player"
 				}
 			]
 		},
@@ -1506,18 +1509,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Vehicle",
-					"name": "vehicle",
-					"description": ""
+					"name": "vehicle"
 				},
 				{
 					"type": "number",
-					"name": "seat_index",
-					"description": ""
+					"name": "seat_index"
 				}
 			]
 		},
@@ -1528,24 +1528,23 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Vehicle",
-					"name": "vehicle",
-					"description": ""
+					"name": "vehicle"
 				},
 				{
 					"type": "number",
-					"name": "seat_index",
-					"description": ""
+					"name": "seat_index"
 				}
 			],
-			"return": {
-				"type": "boolean",
-				"description": "Return <code>false</code> to prevent it"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "Return <code>false</code> to prevent it"
+				}
+			]
 		},
 		{
 			"authority": "both",
@@ -1554,18 +1553,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "FallingMode",
-					"name": "old_state",
-					"description": ""
+					"name": "old_state"
 				},
 				{
 					"type": "FallingMode",
-					"name": "new_state",
-					"description": ""
+					"name": "new_state"
 				}
 			]
 		},
@@ -1576,13 +1572,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Weapon",
-					"name": "weapon",
-					"description": ""
+					"name": "weapon"
 				}
 			]
 		},
@@ -1593,18 +1587,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "GaitMode",
-					"name": "old_state",
-					"description": ""
+					"name": "old_state"
 				},
 				{
 					"type": "GaitMode",
-					"name": "new_state",
-					"description": ""
+					"name": "new_state"
 				}
 			]
 		},
@@ -1615,13 +1606,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Prop",
-					"name": "prop",
-					"description": ""
+					"name": "prop"
 				}
 			]
 		},
@@ -1632,18 +1621,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "number",
-					"name": "old_health",
-					"description": ""
+					"name": "old_health"
 				},
 				{
 					"type": "number",
-					"name": "new_health",
-					"description": ""
+					"name": "new_health"
 				}
 			]
 		},
@@ -1654,8 +1640,7 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "boolean",
@@ -1664,8 +1649,7 @@
 				},
 				{
 					"type": "Prop|Pickable",
-					"name": "object",
-					"description": ""
+					"name": "object"
 				}
 			]
 		},
@@ -1676,19 +1660,19 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Prop|Pickable",
-					"name": "object",
-					"description": ""
+					"name": "object"
 				}
 			],
-			"return": {
-				"type": "boolean",
-				"description": "Return <code>false</code> to prevent it"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "Return <code>false</code> to prevent it"
+				}
+			]
 		},
 		{
 			"authority": "both",
@@ -1697,13 +1681,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Vehicle",
-					"name": "vehicle",
-					"description": ""
+					"name": "vehicle"
 				}
 			]
 		},
@@ -1714,19 +1696,19 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Vehicle",
-					"name": "vehicle",
-					"description": ""
+					"name": "vehicle"
 				}
 			],
-			"return": {
-				"type": "boolean",
-				"description": "Return <code>false</code> to prevent it"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "Return <code>false</code> to prevent it"
+				}
+			]
 		},
 		{
 			"authority": "both",
@@ -1735,13 +1717,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "boolean",
-					"name": "succeeded",
-					"description": ""
+					"name": "succeeded"
 				}
 			]
 		},
@@ -1752,13 +1732,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Pickable",
-					"name": "object",
-					"description": ""
+					"name": "object"
 				}
 			]
 		},
@@ -1769,13 +1747,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Player",
-					"name": "possesser",
-					"description": ""
+					"name": "possesser"
 				}
 			]
 		},
@@ -1786,8 +1762,7 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				}
 			]
 		},
@@ -1798,18 +1773,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "boolean",
-					"name": "old_state",
-					"description": ""
+					"name": "old_state"
 				},
 				{
 					"type": "boolean",
-					"name": "new_state",
-					"description": ""
+					"name": "new_state"
 				}
 			]
 		},
@@ -1820,19 +1792,19 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Weapon",
-					"name": "weapon",
-					"description": ""
+					"name": "weapon"
 				}
 			],
-			"return": {
-				"type": "boolean",
-				"description": "Return <code>false</code> to prevent it"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "Return <code>false</code> to prevent it"
+				}
+			]
 		},
 		{
 			"authority": "both",
@@ -1841,18 +1813,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Weapon",
-					"name": "weapon",
-					"description": ""
+					"name": "weapon"
 				},
 				{
 					"type": "number",
-					"name": "ammo_to_reload",
-					"description": ""
+					"name": "ammo_to_reload"
 				}
 			]
 		},
@@ -1863,8 +1832,7 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				}
 			]
 		},
@@ -1875,18 +1843,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "StanceMode",
-					"name": "old_state",
-					"description": ""
+					"name": "old_state"
 				},
 				{
 					"type": "StanceMode",
-					"name": "new_state",
-					"description": ""
+					"name": "new_state"
 				}
 			]
 		},
@@ -1897,18 +1862,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "SwimmingMode",
-					"name": "old_state",
-					"description": ""
+					"name": "old_state"
 				},
 				{
 					"type": "SwimmingMode",
-					"name": "new_state",
-					"description": ""
+					"name": "new_state"
 				}
 			]
 		},
@@ -1919,13 +1881,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "number",
-					"name": "damage",
-					"description": ""
+					"name": "damage"
 				},
 				{
 					"type": "string",
@@ -1953,10 +1913,12 @@
 					"description": "The object which caused the damage"
 				}
 			],
-			"return": {
-				"type": "boolean",
-				"description": "Return <code>false</code> to cancel the damage (will still display animations, particles and apply impact forces)"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "Return <code>false</code> to cancel the damage (will still display animations, particles and apply impact forces)"
+				}
+			]
 		},
 		{
 			"authority": "both",
@@ -1965,13 +1927,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Prop",
-					"name": "prop",
-					"description": ""
+					"name": "prop"
 				}
 			]
 		},
@@ -1982,13 +1942,11 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "Player",
-					"name": "old_possesser",
-					"description": ""
+					"name": "old_possesser"
 				}
 			]
 		},
@@ -1999,18 +1957,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "ViewMode",
-					"name": "old_state",
-					"description": ""
+					"name": "old_state"
 				},
 				{
 					"type": "ViewMode",
-					"name": "new_state",
-					"description": ""
+					"name": "new_state"
 				}
 			]
 		},
@@ -2021,18 +1976,15 @@
 			"arguments": [
 				{
 					"type": "Character",
-					"name": "self",
-					"description": ""
+					"name": "self"
 				},
 				{
 					"type": "AimMode",
-					"name": "old_state",
-					"description": ""
+					"name": "old_state"
 				},
 				{
 					"type": "AimMode",
-					"name": "new_state",
-					"description": ""
+					"name": "new_state"
 				}
 			]
 		}

--- a/Classes/File.json
+++ b/Classes/File.json
@@ -27,46 +27,56 @@
 			"description": "Flushes content to the file"
 		},
 		{
-			"return": {
-				"type": "boolean",
-				"description": "if is EOF"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if is EOF"
+				}
+			],
 			"authority":"server",
 			"name": "IsEOF",
 			"description": "Checks if the file status is End of File"
 		},
 		{
-			"return": {
-				"type": "boolean",
-				"description": "if status is Bad"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if status is Bad"
+				}
+			],
 			"authority":"server",
 			"name": "IsBad",
 			"description": "Checks if the file status is Bad"
 		},
 		{
-			"return": {
-				"type": "boolean",
-				"description": "if status is Good"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if status is Good"
+				}
+			],
 			"authority":"server",
 			"name": "IsGood",
 			"description": "Checks if the file status is Good"
 		},
 		{
-			"return": {
-				"type": "boolean",
-				"description": "if last operation failed"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if last operation failed"
+				}
+			],
 			"authority":"server",
 			"name": "HasFailed",
 			"description": "Checks if the last operation has Failed"
 		},
 		{
-			"return": {
-				"type": "string",
-				"description": "file data"
-			},
+			"return": [
+				{
+					"type": "string",
+					"description": "file data"
+				}
+			],
 			"authority":"server",
 			"name": "Read",
 			"description": "Reads characters from the File and returns it. Also moves the file pointer to the latest read position. Pass 0 to read the whole file",
@@ -97,10 +107,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string",
-				"description": "file line data"
-			},
+			"return": [
+				{
+					"type": "string",
+					"description": "file line data"
+				}
+			],
 			"authority":"server",
 			"name": "ReadLine",
 			"description": "Reads and returns the next file line"
@@ -118,10 +130,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "number",
-				"description": "file size"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "file size"
+				}
+			],
 			"authority":"server",
 			"name": "Size",
 			"description": "Returns the size of the file"
@@ -139,10 +153,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "number",
-				"description": "current file pointer position"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "current file pointer position"
+				}
+			],
 			"authority":"server",
 			"name": "Tell",
 			"description": "Returns the current file pointer position"
@@ -164,10 +180,12 @@
 		{
 			"type": "number",
 			"name": "Time",
-			"return": {
-				"type": "number",
-				"description": "the last update time in unix time"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "the last update time in unix time"
+				}
+			],
 			"description": "Returns when a file was last modified in Unix time",
 			"authority": "server",
 			"parameters": [
@@ -181,10 +199,12 @@
 		{
 			"type": "boolean",
 			"name": "CreateDirectory",
-			"return": {
-				"type": "boolean",
-				"description": "if succeeded"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if succeeded"
+				}
+			],
 			"description": "Creates a Directory (for every folder passed)",
 			"authority": "server",
 			"parameters": [
@@ -197,10 +217,12 @@
 		},
 		{
 			"name": "Remove",
-			"return": {
-				"type": "number",
-				"description": "amount of files deleted"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "amount of files deleted"
+				}
+			],
 			"description": "Deletes a folder or file",
 			"authority": "server",
 			"parameters": [
@@ -213,10 +235,12 @@
 		},
 		{
 			"name": "Exists",
-			"return": {
-				"type": "boolean",
-				"description": "if exists"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if exists"
+				}
+			],
 			"description": "Verifies if a entry exists in the file system",
 			"authority": "server",
 			"parameters": [
@@ -229,10 +253,12 @@
 		},
 		{
 			"name": "IsDirectory",
-			"return": {
-				"type": "boolean",
-				"description": "if is a directory"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if is a directory"
+				}
+			],
 			"description": "Checks if a path is a directory",
 			"authority": "server",
 			"parameters": [
@@ -245,10 +271,12 @@
 		},
 		{
 			"name": "IsRegularFile",
-			"return": {
-				"type": "boolean",
-				"description": "if is a regular file"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if is a regular file"
+				}
+			],
 			"description": "Checks if a path is a file",
 			"authority": "server",
 			"parameters": [

--- a/Classes/StaticMesh.json
+++ b/Classes/StaticMesh.json
@@ -32,19 +32,23 @@
 		{
 			"name": "GetMesh",
 			"description": "Gets the Asset path mesh used",
-			"return": {
-				"type": "StaticMeshPath",
-				"description": "asset path"
-			},
+			"return": [
+				{
+					"type": "StaticMeshPath",
+					"description": "asset path"
+				}
+			],
 			"authority": "both"
 		},
 		{
 			"name": "IsFromLevel",
 			"description": "Gets if this StaticMesh is from the Level",
-			"return": {
-				"type": "boolean",
-				"description": "if this StaticMesh is from the level"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "if this StaticMesh is from the level"
+				}
+			],
 			"authority": "client"
 		}
 	],

--- a/Classes/Weapon.json
+++ b/Classes/Weapon.json
@@ -511,213 +511,273 @@
 			"authority": "both",
 			"name": "GetAmmoBag",
 			"description": "Gets this Weapon's Ammo Bag",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetAmmoClip",
 			"description": "Gets this Weapon's Ammo Clip",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetAmmoToReload",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetHandlingMode",
-			"return": {
-				"type": "HandlingMode"
-			}
+			"return": [
+				{
+					"type": "HandlingMode"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetAnimationCharacterFire",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetAnimationFire",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetMagazineMesh",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetParticlesBulletTrail",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetParticlesShells",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSoundDry",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSoundLoad",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSoundUnload",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSoundZooming",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSoundAim",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSoundFire",
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCanHoldUse",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetHoldReleaseUse",
-			"return": {
-				"type": "boolean"
-			}
+			"return": [
+				{
+					"type": "boolean"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetBulletCount",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetBulletColor",
-			"return": {
-				"type": "Color"
-			}
+			"return": [
+				{
+					"type": "Color"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetCadence",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetClipCapacity",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetDamage",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetRightHandOffset",
-			"return": {
-				"type": "Vector"
-			}
+			"return": [
+				{
+					"type": "Vector"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetLeftHandLocation",
-			"return": {
-				"type": "Vector"
-			}
+			"return": [
+				{
+					"type": "Vector"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetLeftHandRotation",
-			"return": {
-				"type": "Rotator"
-			}
+			"return": [
+				{
+					"type": "Rotator"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSightLocation",
-			"return": {
-				"type": "Vector"
-			}
+			"return": [
+				{
+					"type": "Vector"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSightRotation",
-			"return": {
-				"type": "Rotator"
-			}
+			"return": [
+				{
+					"type": "Rotator"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSightFOVMultiplier",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetSpread",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "both",
 			"name": "GetRecoil",
-			"return": {
-				"type": "number"
-			}
+			"return": [
+				{
+					"type": "number"
+				}
+			]
 		}
 	],
 	"events": [

--- a/StaticClasses/Assets.json
+++ b/StaticClasses/Assets.json
@@ -4,10 +4,12 @@
 	"authority": "both",
 	"static_functions": [
 		{
-			"return": {
-				"type": "table[]",
-				"description": "in the format <code>[{Name, Path, Author, Version}, ...]</code>"
-			},
+			"return": [
+				{
+					"type": "table[]",
+					"description": "in the format <code>[{Name, Path, Author, Version}, ...]</code>"
+				}
+			],
 			"name": "GetAssetPacks",
 			"description": "Gets a list containing information about all loaded Asset Packs",
 			"authority": "both",
@@ -20,10 +22,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string[]",
-				"description": "array of strings"
-			},
+			"return": [
+				{
+					"type": "string[]",
+					"description": "array of strings"
+				}
+			],
 			"name": "GetAnimations",
 			"description": "Gets a list containing all Animation Assets Keys from an AssetPack",
 			"authority": "both",
@@ -36,10 +40,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string[]",
-				"description": "array of strings"
-			},
+			"return": [
+				{
+					"type": "string[]",
+					"description": "array of strings"
+				}
+			],
 			"name": "GetMaps",
 			"description": "Gets a list containing all Map Asset Keys from an AssetPack",
 			"authority": "both",
@@ -52,10 +58,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string[]",
-				"description": "array of strings"
-			},
+			"return": [
+				{
+					"type": "string[]",
+					"description": "array of strings"
+				}
+			],
 			"name": "GetMaterials",
 			"description": "Gets a list containing all Materials Asset Keys from an AssetPack",
 			"authority": "both",
@@ -68,10 +76,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string[]",
-				"description": "array of strings"
-			},
+			"return": [
+				{
+					"type": "string[]",
+					"description": "array of strings"
+				}
+			],
 			"name": "GetParticles",
 			"description": "Gets a list containing all Particle Assets Keys from an AssetPack",
 			"authority": "both",
@@ -84,10 +94,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string[]",
-				"description": "array of strings"
-			},
+			"return": [
+				{
+					"type": "string[]",
+					"description": "array of strings"
+				}
+			],
 			"name": "GetSounds",
 			"description": "Gets a list containing all Sound Assets Keys from an AssetPack",
 			"authority": "both",
@@ -100,10 +112,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string[]",
-				"description": "array of strings"
-			},
+			"return": [
+				{
+					"type": "string[]",
+					"description": "array of strings"
+				}
+			],
 			"name": "GetSkeletalMeshes",
 			"description": "Gets a list containing all Skeletal Mesh Asset Keys from an AssetPack",
 			"authority": "both",
@@ -116,10 +130,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string[]",
-				"description": "array of strings"
-			},
+			"return": [
+				{
+					"type": "string[]",
+					"description": "array of strings"
+				}
+			],
 			"name": "GetStaticMeshes",
 			"description": "Gets a list containing all Static Mesh Assets Keys from an AssetPack",
 			"authority": "both",
@@ -132,10 +148,12 @@
 			]
 		},
 		{
-			"return": {
-				"type": "string[]",
-				"description": "array of strings"
-			},
+			"return": [
+				{
+					"type": "string[]",
+					"description": "array of strings"
+				}
+			],
 			"name": "GetOthers",
 			"description": "Gets a list containing all Other Assets Keys from an AssetPack",
 			"authority": "both",

--- a/StaticClasses/Events.json
+++ b/StaticClasses/Events.json
@@ -82,10 +82,12 @@
 		},
 		{
 			"authority": "both",
-			"return": {
-				"type": "function",
-				"description": "the subscribed callback itself"
-			},
+			"return": [
+				{
+					"type": "function",
+					"description": "the subscribed callback itself"
+				}
+			],
 			"name": "Subscribe",
 			"description": "Subscribes for an user-created event which will be triggered for both local or remote called events",
 			"parameters": [

--- a/StaticClasses/HTTP.json
+++ b/StaticClasses/HTTP.json
@@ -60,10 +60,12 @@
 		},
 		{
 			"name": "RequestSync",
-			"return": {
-				"type": "table",
-				"description": "the data in the format <code>{ Status, Data }</code>"
-			},
+			"return": [
+				{
+					"type": "table",
+					"description": "the data in the format <code>{ Status, Data }</code>"
+				}
+			],
 			"description": "Makes a synchronous HTTP Request.<br/><br/>The request will be made synchronously and will freeze the server until it's done.",
 			"authority": "server",
 			"parameters": [

--- a/StaticClasses/Input.json
+++ b/StaticClasses/Input.json
@@ -55,8 +55,7 @@
 				},
 				{
 					"type": "string",
-					"name": "key_name",
-					"description": ""
+					"name": "key_name"
 				}
 			]
 		},
@@ -72,8 +71,7 @@
 				},
 				{
 					"type": "string",
-					"name": "key_name",
-					"description": ""
+					"name": "key_name"
 				}
 			]
 		},
@@ -85,19 +83,19 @@
 				{
 					"type": "string",
 					"name": "key_name",
-					"default": "",
-					"description": ""
+					"default": ""
 				},
 				{
 					"type": "boolean",
 					"name": "dark_mode",
-					"default": "false",
-					"description": ""
+					"default": "false"
 				}
 			],
-			"return": {
-				"type": "string"
-			}
+			"return": [
+				{
+					"type": "string"
+				}
+			]
 		},
 		{
 			"authority": "client",
@@ -110,9 +108,14 @@
 					"description": "The keybinding id"
 				}
 			],
-			"return": {
-				"type": "string,number"
-			}
+			"return": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "number"
+				}
+			]
 		},
 		{
 			"authority": "client",
@@ -123,9 +126,11 @@
 			"authority": "client",
 			"name": "GetScriptingKeyBindings",
 			"description": "Returns a table with all Scripting KeyBindings",
-			"return": {
-				"type": "table"
-			}
+			"return": [
+				{
+					"type": "table"
+				}
+			]
 		}
 	]
 }

--- a/StaticClasses/Package.json
+++ b/StaticClasses/Package.json
@@ -79,10 +79,12 @@
 					"description": "Arguments to pass to the function"
 				}
 			],
-			"return": {
-				"type": "any",
-				"description": "Any return values from the called function"
-			}
+			"return": [
+				{
+					"type": "any",
+					"description": "Any return values from the called function"
+				}
+			]
 		},
 		{
 			"name": "Export",
@@ -142,10 +144,12 @@
 					"description": "Callback to run on the event occuring"
 				}
 			],
-			"return": {
-				"type": "function",
-				"description": "The function callback"
-			}
+			"return": [
+				{
+					"type": "function",
+					"description": "The function callback"
+				}
+			]
 		},
 		{
 			"name": "Unsubscribe",
@@ -195,11 +199,12 @@
 					"description": "Path filter"
 				}
 			],
-			"return": {
-				"type": "string",
-				"is_array": true,
-				"description": "List of directories"
-			}
+			"return": [
+				{
+					"type": "string[]",
+					"description": "List of directories"
+				}
+			]
 		},
 		{
 			"name": "GetFiles",
@@ -214,47 +219,56 @@
 					"description": "Path filter"
 				}
 			],
-			"return": {
-				"type": "string",
-				"is_array": true,
-				"description": "List of files"
-			}
+			"return": [
+				{
+					"type": "string[]",
+					"description": "List of files"
+				}
+			]
 		},
 		{
 			"name": "GetName",
 			"description": "Gives the package name",
 			"authority": "both",
-			"return": {
-				"type": "string",
-				"description": "The package name"
-			}
+			"return": [
+				{
+					"type": "string",
+					"description": "The package name"
+				}
+			]
 		},
 		{
 			"name": "GetPath",
 			"description": "Gives the package path",
 			"authority": "both",
-			"return": {
-				"type": "string",
-				"description": "The package path"
-			}
+			"return": [
+				{
+					"type": "string",
+					"description": "The package path"
+				}
+			]
 		},
 		{
 			"name": "GetVersion",
 			"description": "Gives the package version",
 			"authority": "both",
-			"return": {
-				"type": "string",
-				"description": "The package version"
-			}
+			"return": [
+				{
+					"type": "string",
+					"description": "The package version"
+				}
+			]
 		},
 		{
 			"name": "GetPersistentData",
 			"description": "Gets all Persistent Values from the disk",
 			"authority": "both",
-			"return": {
-				"type": "table",
-				"description": "Persistent values from disk"
-			}
+			"return": [
+				{
+					"type": "table",
+					"description": "Persistent values from disk"
+				}
+			]
 		}
 	],
 	"events": [

--- a/Structs/Matrix.json
+++ b/Structs/Matrix.json
@@ -17,10 +17,12 @@
 		{
 			"name": "TransformVector",
 			"description": "Transform the vector with the matrix",
-			"return": {
-				"type": "Vector",
-				"description": "The new vector"
-			},
+			"return": [
+				{
+					"type": "Vector",
+					"description": "The new vector"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Vector",
@@ -32,10 +34,12 @@
 		{
 			"name": "TransformVector4",
 			"description": "Transform the vector with the matrix",
-			"return": {
-				"type": "Vector4",
-				"description": "The new vector4"
-			},
+			"return": [
+				{
+					"type": "Vector4",
+					"description": "The new vector4"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Vector4",
@@ -47,10 +51,12 @@
 		{
 			"name": "GetTransposed",
 			"description": "Returns a new matrix transposed (https://en.wikipedia.org/wiki/Transpose)",
-			"return": {
-				"type": "Matrix",
-				"description": "The matrix transpoosed"
-			}
+			"return": [
+				{
+					"type": "Matrix",
+					"description": "The matrix transpoosed"
+				}
+			]
 		}
 	]
 }

--- a/Structs/Vector.json
+++ b/Structs/Vector.json
@@ -43,10 +43,12 @@
 			"name": "Equals",
 			"description": "Check against another vector for equality, within specified error limits",
 			"description_long": "Check if the vector is equal to another vector, within specified error limits",
-			"return": {
-				"type": "boolean",
-				"description": "Are the vectors equal or not"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "Are the vectors equal or not"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Vector",
@@ -65,10 +67,12 @@
 			"name": "Distance",
 			"description": "Distance between two points",
 			"description_long": "Returns the distance of 2 vectors",
-			"return": {
-				"type": "number",
-				"description": "The distance betweem the vectors"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "The distance betweem the vectors"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Vector",
@@ -81,10 +85,12 @@
 			"name": "DistanceSquared",
 			"description": "Squared distance between two points",
 			"description_long": "Return the squared distance of 2 vectors",
-			"return": {
-				"type": "number",
-				"description": "The squared distance betweem the vectors"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "The squared distance betweem the vectors"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Vector",
@@ -97,29 +103,35 @@
 			"name": "GetUnsafeNormal",
 			"description": "Calculates normalized version of vector without checking for zero length",
 			"description_long": "Returns the normalized version of vector without checking for zero length",
-			"return": {
-				"type": "Vector",
-				"description": "The unsafe normal"
-			},
+			"return": [
+				{
+					"type": "Vector",
+					"description": "The unsafe normal"
+				}
+			],
 			"parameters": []
 		},
 		{
 			"name": "GetSafeNormal",
 			"description": "Gets a normalized copy of the vector, checking it is safe to do so based on the length",
 			"description_long": "Returns a normalized copy of the vector, checking it is safe to do so based on the length",
-			"return": {
-				"type": "Vector",
-				"description": "The safe normal"
-			},
+			"return": [
+				{
+					"type": "Vector",
+					"description": "The safe normal"
+				}
+			],
 			"parameters": []
 		},
 		{
 			"name": "IsNearlyZero",
 			"description": "Checks whether vector is near to zero within a specified tolerance",
-			"return": {
-				"type": "boolean",
-				"description": "If the bool is near to zero"
-			},
+			"return": [
+				{
+					"type": "boolean",
+					"description": "If the bool is near to zero"
+				}
+			],
 			"parameters": [
 				{
 					"type": "number",
@@ -132,42 +144,52 @@
 		{
 			"name": "IsZero",
 			"description": "Checks whether all components of the vector are exactly zero",
-			"return": {
-				"type": "boolean",
-				"description": "If all components of the vector are exactly zero"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "If all components of the vector are exactly zero"
+				}
+			]
 		},
 		{
 			"name": "Normalize",
 			"description": "Normalize this vector in-place if it is larger than a given tolerance. Leaves it unchanged if not",
-			"return": {
-				"type": "boolean",
-				"description": "If the vector has been modified"
-			}
+			"return": [
+				{
+					"type": "boolean",
+					"description": "If the vector has been modified"
+				}
+			]
 		},
 		{
 			"name": "Size",
 			"description": "Get the length (magnitude) of this vector",
-			"return": {
-				"type": "number",
-				"description": "The lenght of the vector"
-			}
+			"return": [
+				{
+					"type": "number",
+					"description": "The lenght of the vector"
+				}
+			]
 		},
 		{
 			"name": "SizeSquared",
 			"description": "Get the squared length of this vector",
-			"return": {
-				"type": "number",
-				"description": "The squared length of the vector"
-			}
+			"return": [
+				{
+					"type": "number",
+					"description": "The squared length of the vector"
+				}
+			]
 		},
 		{
 			"name": "Rotation",
 			"description": "Returns the orientation corresponding to the direction in which the vector points",
-			"return": {
-				"type": "Rotator",
-				"description": "The orientation of the vector"
-			}
+			"return": [
+				{
+					"type": "Rotator",
+					"description": "The orientation of the vector"
+				}
+			]
 		}
 	]
 }

--- a/UtilityClasses/NanosMath.json
+++ b/UtilityClasses/NanosMath.json
@@ -5,10 +5,12 @@
 		{
 			"name": "Round",
 			"description": "Rounds a number",
-			"return": {
-				"type": "number",
-				"description": "the rounded number"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "the rounded number"
+				}
+			],
 			"parameters": [
 				{
 					"type": "number",
@@ -20,10 +22,12 @@
 		{
 			"name": "Clamp",
 			"description": "Clamps a number",
-			"return": {
-				"type": "number",
-				"description": "the number clamped"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "the number clamped"
+				}
+			],
 			"parameters": [
 				{
 					"type": "number",
@@ -45,10 +49,12 @@
 		{
 			"name": "ClampAxis",
 			"description": "Clamps an angle to the range of [0, 360]",
-			"return": {
-				"type": "number",
-				"description": "the number clamped"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "the number clamped"
+				}
+			],
 			"parameters": [
 				{
 					"type": "number",
@@ -60,10 +66,12 @@
 		{
 			"name": "NormalizeAxis",
 			"description": "Clamps an angle to the range of [-180, 180]",
-			"return": {
-				"type": "number",
-				"description": "the number clamped"
-			},
+			"return": [
+				{
+					"type": "number",
+					"description": "the number clamped"
+				}
+			],
 			"parameters": [
 				{
 					"type": "number",
@@ -75,10 +83,16 @@
 		{
 			"name": "RelativeTo",
 			"description": "Calculates the location and rotation relative to an actor",
-			"return": {
-				"type": "Vector,Rotator",
-				"description": "the location and rotation relative to the actor"
-			},
+			"return": [
+				{
+					"type": "Vector",
+					"description": "the location relative to the actor"
+				},
+				{
+					"type": "Rotator",
+					"description": "The rotation relative to the actor"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Vector",
@@ -100,150 +114,135 @@
 		{
 			"name": "FInterpTo",
 			"description": "Interpolate number from Current to Target",
-			"return": {
-				"type": "number",
-				"description": ""
-			},
+			"return": [
+				{
+					"type": "number"
+				}
+			],
 			"parameters": [
 				{
 					"type": "number",
-					"name": "current",
-					"description": ""
+					"name": "current"
 				},
 				{
 					"type": "number",
-					"name": "target",
-					"description": ""
+					"name": "target"
 				},
 				{
 					"type": "number",
-					"name": "delta_time",
-					"description": ""
+					"name": "delta_time"
 				},
 				{
 					"type": "number",
-					"name": "interp_speed",
-					"description": ""
+					"name": "interp_speed"
 				}
 			]
 		},
 		{
 			"name": "RInterpTo",
 			"description": "Interpolate Rotator from Current to Target",
-			"return": {
-				"type": "Rotator",
-				"description": ""
-			},
+			"return": [
+				{
+					"type": "Rotator"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Rotator",
-					"name": "current",
-					"description": ""
+					"name": "current"
 				},
 				{
 					"type": "Rotator",
-					"name": "target",
-					"description": ""
+					"name": "target"
 				},
 				{
 					"type": "number",
-					"name": "delta_time",
-					"description": ""
+					"name": "delta_time"
 				},
 				{
 					"type": "number",
-					"name": "interp_speed",
-					"description": ""
+					"name": "interp_speed"
 				}
 			]
 		},
 		{
 			"name": "RInterpConstantTo",
 			"description": "Interpolate Rotator from Current to Target with a constant step",
-			"return": {
-				"type": "Rotator",
-				"description": ""
-			},
+			"return": [
+				{
+					"type": "Rotator"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Rotator",
-					"name": "current",
-					"description": ""
+					"name": "current"
 				},
 				{
 					"type": "Rotator",
-					"name": "target",
-					"description": ""
+					"name": "target"
 				},
 				{
 					"type": "number",
-					"name": "delta_time",
-					"description": ""
+					"name": "delta_time"
 				},
 				{
 					"type": "number",
-					"name": "interp_speed",
-					"description": ""
+					"name": "interp_speed"
 				}
 			]
 		},
 		{
 			"name": "VInterpTo",
 			"description": "Interpolate Vector from Current to Target",
-			"return": {
-				"type": "Vector",
-				"description": ""
-			},
+			"return": [
+				{
+					"type": "Vector"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Vector",
-					"name": "current",
-					"description": ""
+					"name": "current"
 				},
 				{
 					"type": "Vector",
-					"name": "target",
-					"description": ""
+					"name": "target"
 				},
 				{
 					"type": "number",
-					"name": "delta_time",
-					"description": ""
+					"name": "delta_time"
 				},
 				{
 					"type": "number",
-					"name": "interp_speed",
-					"description": ""
+					"name": "interp_speed"
 				}
 			]
 		},
 		{
 			"name": "VInterpConstantTo",
 			"description": "Interpolate Vector from Current to Target with a constant step",
-			"return": {
-				"type": "Vector",
-				"description": ""
-			},
+			"return": [
+				{
+					"type": "Vector"
+				}
+			],
 			"parameters": [
 				{
 					"type": "Vector",
-					"name": "current",
-					"description": ""
+					"name": "current"
 				},
 				{
 					"type": "Vector",
-					"name": "target",
-					"description": ""
+					"name": "target"
 				},
 				{
 					"type": "number",
-					"name": "delta_time",
-					"description": ""
+					"name": "delta_time"
 				},
 				{
 					"type": "number",
-					"name": "interp_speed",
-					"description": ""
+					"name": "interp_speed"
 				}
 			]
 		}


### PR DESCRIPTION
Converted all `"return"` fields to an array to allow for multiple return values (as well as per-return descriptions)

Cleaned up some areas of the json like empty descriptions and an instance of `is_array`